### PR TITLE
Update Fluree-LinkML HTTP notebook data paths, artefacts

### DIFF
--- a/notebooks/linkml-fluree.ipynb
+++ b/notebooks/linkml-fluree.ipynb
@@ -35,11 +35,11 @@
    },
    "outputs": [],
    "source": [
-    "%env ONTOLOGY_FILE=../ontology/mwb-ontology.owl.yaml\n",
-    "%env OUTPUT_DIR=../output\n",
-    "%env OUTPUT_VIZ=../output/Data-centric-app-demo.jpg\n",
-    "%env OUTPUT_OWL=../output/mwb-ontology.owl.ttl\n",
-    "%env OUTPUT_SHACL=../output/mwb-shapes.shacl.ttl"
+    "%env ONTOLOGY_FILE=../resources/mwb-ontology.owl.yaml\n",
+    "%env OUTPUT_DIR=../resources\n",
+    "%env OUTPUT_VIZ=../resources/Data-centric-app-demo.jpg\n",
+    "%env OUTPUT_OWL=../resources/mwb-ontology.owl.ttl\n",
+    "%env OUTPUT_SHACL=../resources/mwb-shapes.shacl.ttl"
    ]
   },
   {
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "%env DATA_FILE=../tests/test_data/mwb-demo-data.yaml\n",
-    "%env OUTPUT_DATA=../output/mwb-demo-data.ttl"
+    "%env OUTPUT_DATA=../resources/mwb-demo-data.ttl"
    ]
   },
   {
@@ -749,7 +749,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/resources/mwb-demo-data.ttl
+++ b/resources/mwb-demo-data.ttl
@@ -1,0 +1,22 @@
+@prefix mnfy: <https://meaningfy.ws/data-centric-app-demo/> .
+@prefix schema1: <http://schema.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+mnfy:1234 a schema1:Person ;
+    schema1:name "Clark Kent" ;
+    schema1:telephone "555-555-5555" ;
+    mnfy:age 33 .
+
+mnfy:4567 a schema1:Person ;
+    schema1:name "Lois Lane" ;
+    mnfy:age 34 .
+
+mnfy:7890 a mnfy:Company ;
+    schema1:name "ABC Inc." ;
+    schema1:telephone "555-555-5555" .
+
+[] a mnfy:Container ;
+    mnfy:companies mnfy:7890 ;
+    mnfy:persons mnfy:1234,
+        mnfy:4567 .
+

--- a/resources/mwb-ontology.owl.ttl
+++ b/resources/mwb-ontology.owl.ttl
@@ -15,11 +15,11 @@ mnfy:Container a owl:Class ;
             owl:minCardinality 0 ;
             owl:onProperty mnfy:persons ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty mnfy:companies ],
-        [ a owl:Restriction ;
             owl:allValuesFrom mnfy:Person ;
             owl:onProperty mnfy:persons ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty mnfy:companies ],
         [ a owl:Restriction ;
             owl:allValuesFrom mnfy:Company ;
             owl:onProperty mnfy:companies ] ;
@@ -28,19 +28,34 @@ mnfy:Container a owl:Class ;
 mnfy:Company a owl:Class ;
     rdfs:label "Company" ;
     rdfs:subClassOf [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty mnfy:aliases ],
+        [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty mnfy:aliases ],
         [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty mnfy:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
+            owl:maxCardinality 1 ;
             owl:onProperty mnfy:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom xsd:string ;
             owl:onProperty mnfy:name ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
+            owl:onProperty mnfy:phone ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty mnfy:id ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom mnfy:Person ;
+            owl:onProperty mnfy:employs ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty mnfy:phone ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty mnfy:name ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty mnfy:id ],
         [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
@@ -48,48 +63,16 @@ mnfy:Company a owl:Class ;
                     owl:withRestrictions ( [ xsd:pattern "^[\\d\\(\\)\\-]+$" ] ) ] ;
             owl:onProperty mnfy:phone ],
         [ a owl:Restriction ;
-            owl:allValuesFrom mnfy:Person ;
-            owl:onProperty mnfy:employs ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty mnfy:name ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty mnfy:phone ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty mnfy:phone ],
-        [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty mnfy:employs ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty mnfy:id ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty mnfy:aliases ] ;
+            owl:maxCardinality 1 ;
+            owl:onProperty mnfy:name ] ;
     skos:inScheme <https://meaningfy.ws/data-centric-app-demo> .
 
 mnfy:Person a owl:Class ;
     rdfs:label "Person" ;
     rdfs:subClassOf [ a owl:Restriction ;
-            owl:allValuesFrom [ a rdfs:Datatype ;
-                    owl:onDatatype xsd:string ;
-                    owl:withRestrictions ( [ xsd:pattern "^[\\d\\(\\)\\-]+$" ] ) ] ;
-            owl:onProperty mnfy:phone ],
-        [ a owl:Restriction ;
-            owl:minCardinality 1 ;
-            owl:onProperty mnfy:name ],
-        [ a owl:Restriction ;
-            owl:minCardinality 0 ;
-            owl:onProperty mnfy:phone ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty mnfy:age ],
-        [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty mnfy:name ],
-        [ a owl:Restriction ;
             owl:allValuesFrom [ a rdfs:Datatype ;
                     owl:intersectionOf ( xsd:integer [ a rdfs:Datatype ;
                                 owl:onDatatype xsd:integer ;
@@ -98,29 +81,46 @@ mnfy:Person a owl:Class ;
                                 owl:withRestrictions ( [ xsd:maxInclusive 200 ] ) ] ) ] ;
             owl:onProperty mnfy:age ],
         [ a owl:Restriction ;
-            owl:minCardinality 0 ;
+            owl:maxCardinality 1 ;
+            owl:onProperty mnfy:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 1 ;
+            owl:onProperty mnfy:name ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty mnfy:age ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
             owl:onProperty mnfy:aliases ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty mnfy:name ],
+        [ a owl:Restriction ;
+            owl:minCardinality 0 ;
+            owl:onProperty mnfy:phone ],
+        [ a owl:Restriction ;
+            owl:allValuesFrom xsd:string ;
+            owl:onProperty mnfy:id ],
+        [ a owl:Restriction ;
+            owl:maxCardinality 1 ;
+            owl:onProperty mnfy:id ],
         [ a owl:Restriction ;
             owl:maxCardinality 1 ;
             owl:onProperty mnfy:phone ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty mnfy:aliases ],
-        [ a owl:Restriction ;
             owl:minCardinality 1 ;
             owl:onProperty mnfy:id ],
-        [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty mnfy:name ],
         [ a owl:Restriction ;
             owl:minCardinality 0 ;
             owl:onProperty mnfy:age ],
         [ a owl:Restriction ;
-            owl:maxCardinality 1 ;
-            owl:onProperty mnfy:id ],
+            owl:minCardinality 0 ;
+            owl:onProperty mnfy:aliases ],
         [ a owl:Restriction ;
-            owl:allValuesFrom xsd:string ;
-            owl:onProperty mnfy:id ] ;
+            owl:allValuesFrom [ a rdfs:Datatype ;
+                    owl:onDatatype xsd:string ;
+                    owl:withRestrictions ( [ xsd:pattern "^[\\d\\(\\)\\-]+$" ] ) ] ;
+            owl:onProperty mnfy:phone ] ;
     skos:exactMatch schema1:Person ;
     skos:inScheme <https://meaningfy.ws/data-centric-app-demo> .
 

--- a/resources/mwb-shapes.shacl.ttl
+++ b/resources/mwb-shapes.shacl.ttl
@@ -20,11 +20,10 @@ mnfy:Container a sh:NodeShape ;
 mnfy:Company a sh:NodeShape ;
     sh:closed true ;
     sh:ignoredProperties ( rdf:type ) ;
-    sh:property [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 0 ;
-            sh:path mnfy:id ],
+    sh:property [ sh:class schema1:Person ;
+            sh:nodeKind sh:IRI ;
+            sh:order 4 ;
+            sh:path mnfy:employs ],
         [ sh:datatype xsd:string ;
             sh:description "name of the person" ;
             sh:maxCount 1 ;
@@ -32,10 +31,11 @@ mnfy:Company a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 1 ;
             sh:path schema1:name ],
-        [ sh:class schema1:Person ;
-            sh:nodeKind sh:IRI ;
-            sh:order 4 ;
-            sh:path mnfy:employs ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 0 ;
+            sh:path mnfy:id ],
         [ sh:datatype xsd:string ;
             sh:maxCount 1 ;
             sh:nodeKind sh:Literal ;
@@ -53,17 +53,6 @@ schema1:Person a sh:NodeShape ;
     sh:closed true ;
     sh:ignoredProperties ( rdf:type ) ;
     sh:property [ sh:datatype xsd:string ;
-            sh:description "other names for the person" ;
-            sh:nodeKind sh:Literal ;
-            sh:order 2 ;
-            sh:path mnfy:aliases ],
-        [ sh:datatype xsd:string ;
-            sh:maxCount 1 ;
-            sh:nodeKind sh:Literal ;
-            sh:order 3 ;
-            sh:path schema1:telephone ;
-            sh:pattern "^[\\d\\(\\)\\-]+$" ],
-        [ sh:datatype xsd:string ;
             sh:description "name of the person" ;
             sh:maxCount 1 ;
             sh:minCount 1 ;
@@ -75,6 +64,17 @@ schema1:Person a sh:NodeShape ;
             sh:nodeKind sh:Literal ;
             sh:order 0 ;
             sh:path mnfy:id ],
+        [ sh:datatype xsd:string ;
+            sh:description "other names for the person" ;
+            sh:nodeKind sh:Literal ;
+            sh:order 2 ;
+            sh:path mnfy:aliases ],
+        [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:order 3 ;
+            sh:path schema1:telephone ;
+            sh:pattern "^[\\d\\(\\)\\-]+$" ],
         [ sh:datatype xsd:integer ;
             sh:maxCount 1 ;
             sh:maxInclusive 200 ;


### PR DESCRIPTION
The resources from the `output` folder have (aptly) moved to a `resources` folder now. Running the notebook again appears to have updated some of these data, likely because the source ontology was updated at some point.

edit: It appears ordering of items in the output may have changed, not necessarily the ontology itself. To be investigated at some other time.